### PR TITLE
feat: implement Timesheet resource with CRUD pages, model, migration,…

### DIFF
--- a/app/Filament/Resources/TimesheetResource.php
+++ b/app/Filament/Resources/TimesheetResource.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\TimesheetResource\Pages;
+use App\Models\Timesheet;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class TimesheetResource extends Resource
+{
+    protected static ?string $model = Timesheet::class;
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('navigation-panel.Logistics');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('timesheets.navegation_label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('timesheets.navegation_label');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('timesheets.navegation_label_singel');
+    }
+
+    protected static ?string $navigationIcon = 'heroicon-o-table-cells';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                //
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('calendar')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('staff_id')
+                    ->numeric()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('user_id')
+                    ->numeric()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('type')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('day_in')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('day_out')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('hours'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListTimesheets::route('/'),
+            // 'create' => Pages\CreateTimesheet::route('/create'),
+            'edit' => Pages\EditTimesheet::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/TimesheetResource/Pages/CreateTimesheet.php
+++ b/app/Filament/Resources/TimesheetResource/Pages/CreateTimesheet.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\TimesheetResource\Pages;
+
+use App\Filament\Resources\TimesheetResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateTimesheet extends CreateRecord
+{
+    protected static string $resource = TimesheetResource::class;
+}

--- a/app/Filament/Resources/TimesheetResource/Pages/EditTimesheet.php
+++ b/app/Filament/Resources/TimesheetResource/Pages/EditTimesheet.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\TimesheetResource\Pages;
+
+use App\Filament\Resources\TimesheetResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditTimesheet extends EditRecord
+{
+    protected static string $resource = TimesheetResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/TimesheetResource/Pages/ListTimesheets.php
+++ b/app/Filament/Resources/TimesheetResource/Pages/ListTimesheets.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\TimesheetResource\Pages;
+
+use App\Filament\Resources\TimesheetResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTimesheets extends ListRecords
+{
+    protected static string $resource = TimesheetResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            // Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Timesheet extends Model
+{
+    protected $fillable = [
+        'calendar',
+        'staff_id',
+        'user_id',
+        'type',
+        'day_in',
+        'day_out',
+        'hours',
+    ];
+
+    public function staff()
+    {
+        return $this->belongsTo(User::class, 'staff_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/database/migrations/2025_08_28_150202_create_timesheets_table.php
+++ b/database/migrations/2025_08_28_150202_create_timesheets_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('timesheets', function (Blueprint $table) {
+            $table->id();
+            $table->string('calendar');
+            $table->foreignId('staff_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('type');
+            $table->dateTime('day_in');
+            $table->dateTime('day_out');
+            $table->time('hours')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('timesheets');
+    }
+};

--- a/lang/es/navigation-panel.php
+++ b/lang/es/navigation-panel.php
@@ -2,4 +2,5 @@
 
 return [
     'Administration' => 'Administración',
+    'Logistics' => 'Logística',
 ];

--- a/lang/es/timesheets.php
+++ b/lang/es/timesheets.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'navegation_label' => 'Asistencias',
+    'navegation_label_singel' => 'Asistencia',
+];


### PR DESCRIPTION
This pull request introduces a new "Timesheet" resource to the application, including its database schema, Eloquent model, Filament resource, and supporting language translations. The changes enable managing timesheet records with staff and user relationships, and provide localized navigation labels.

**Timesheet Resource Implementation**

* Added the `Timesheet` Eloquent model with fillable fields and relationships to the `User` model for both `staff_id` and `user_id`.
* Created a migration for the `timesheets` table, defining relevant fields, foreign keys to the `users` table, and timestamps.

**Filament Resource and Pages**

* Implemented the `TimesheetResource` Filament resource, including table columns, navigation labels, and page definitions for listing and editing timesheets.
* Added Filament resource pages for listing (`ListTimesheets`), editing (`EditTimesheet`), and creating (`CreateTimesheet`) timesheet records. [[1]](diffhunk://#diff-81af09ef3041d52a73f58380f1e2eb74ed026973456ea65198edbf92e731f9cbR1-R19) [[2]](diffhunk://#diff-65100de61a2eef5fafadd0f77bc900259cf913724248786c90960cf02fb52ee0R1-R19) [[3]](diffhunk://#diff-fe82cb51feb0388d9bc6158f2037cbf556dcca87277ad3ac76da0271acdedd7bR1-R11)

**Localization Support**

* Updated Spanish language files to include navigation labels for "Logistics" and the timesheet resource. [[1]](diffhunk://#diff-63b6daeea36502ca491ab8f33c361ab5b28dca1771ae50fe1faf7d58052471a2R5) [[2]](diffhunk://#diff-ec3c1dc9d1389966b2b966492b7cd92e595f652a0ce5b185c5f35b3ed4b26addR1-R6)… and localization

><img width="1335" height="529" alt="image" src="https://github.com/user-attachments/assets/9591f244-2ad5-45c5-b596-7e0bc21fefe5" />
