### PR TITLE
feat: disable registration feature in Fortify configuration

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -144,7 +144,7 @@ return [
     */
 
     'features' => [
-        Features::registration(),
+        // Features::registration(),
         Features::resetPasswords(),
         // Features::emailVerification(),
         Features::updateProfileInformation(),


### PR DESCRIPTION
This pull request makes a small configuration change to the `config/fortify.php` file. The change disables user registration by commenting out the `Features::registration()` feature.

><img width="764" height="642" alt="image" src="https://github.com/user-attachments/assets/db805e76-3dab-486f-acbf-e459974cbd4f" />
