### PR TITLE
feat: add administrative panel links to user menu and navigation

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -7,6 +7,7 @@ use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Navigation\MenuItem;
 use Filament\Pages;
 use Filament\Panel;
 use Filament\PanelProvider;
@@ -54,6 +55,12 @@ class AdminPanelProvider extends PanelProvider
                 SubstituteBindings::class,
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
+            ])
+            ->userMenuItems([
+                'personal' => MenuItem::make()
+                    ->label('Panel Personal')
+                    ->url('/dashboard')
+                    ->icon('heroicon-s-home'),
             ])
             ->plugins([
                 FilamentShieldPlugin::make(),

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -267,7 +267,9 @@
                                         >
                                             Profile
                                         </DropdownLink>
-
+                                        <DropdownLink href="/admin" as="a">
+                                            Panel Administrativo
+                                        </DropdownLink>
                                         <DropdownLink
                                             v-if="
                                                 $page.props.jetstream
@@ -388,7 +390,9 @@
                             >
                                 Profile
                             </ResponsiveNavLink>
-
+                            <ResponsiveNavLink href="/admin" as="a">
+                                Panel Administrativo
+                            </ResponsiveNavLink>
                             <ResponsiveNavLink
                                 v-if="$page.props.jetstream.hasApiFeatures"
                                 :href="route('api-tokens.index')"


### PR DESCRIPTION
This pull request adds a new "Panel Administrativo" menu item to the application's navigation, making it easier for users to access the admin panel from both the dropdown and responsive navigation menus. Additionally, a custom "Panel Personal" item is added to the Filament admin panel's user menu.

Navigation improvements:

* Added a "Panel Administrativo" link to the dropdown menu in `AppLayout.vue`, allowing users to quickly access the admin panel.
* Added a "Panel Administrativo" link to the responsive navigation menu in `AppLayout.vue` for better accessibility on mobile devices.

Filament admin panel customization:

* Imported `MenuItem` in `AdminPanelProvider.php` to enable user menu customization.
* Added a custom "Panel Personal" item to the Filament user menu, linking to the dashboard with a home icon.

><img width="1171" height="642" alt="image" src="https://github.com/user-attachments/assets/0b1f88fa-bfeb-4ebf-89dc-4bb0fe778390" />
