### PR TITLE
feat: implement user-specific visibility for password vault entries

### DIFF
--- a/app/Filament/Resources/PasswordVaultResource.php
+++ b/app/Filament/Resources/PasswordVaultResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources;
 use App\Enums\PasswordTypeEnum;
 use App\Filament\Resources\PasswordVaultResource\Pages;
 use App\Models\PasswordVault;
+use App\Services\Auth\AuthService;
 use App\Services\Utils\PasswordGenerator;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -168,7 +169,10 @@ class PasswordVaultResource extends Resource
 
     public static function getEloquentQuery(): Builder
     {
+        $userId = app(AuthService::class)->getAuthUser()->id;
+
         return parent::getEloquentQuery()
+            ->visibleToUser($userId)
             ->withoutGlobalScopes([
                 SoftDeletingScope::class,
             ]);

--- a/app/Models/PasswordVault.php
+++ b/app/Models/PasswordVault.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Observers\PasswordVaultObserver;
 use App\Traits\Auth\BelongsToAuthenticatedUser;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -33,5 +34,16 @@ class PasswordVault extends Model
     public function passwordShares()
     {
         return $this->hasMany(PasswordShare::class, 'password_id');
+    }
+
+    public function scopeVisibleToUser(Builder $query, $userId)
+    {
+        return $query->where(function ($q) use ($userId) {
+            $q->where('type', 'public')
+                ->orWhere(function ($sub) use ($userId) {
+                    $sub->where('type', 'private')
+                        ->where('user_id', $userId);
+                });
+        });
     }
 }


### PR DESCRIPTION
This pull request introduces a new visibility scope for password vault entries, ensuring that users only see vault entries they are permitted to access. The main changes implement a custom query scope and update resource querying logic to use it.

**Password Vault Visibility Improvements**

* Added a new `scopeVisibleToUser` method to the `PasswordVault` model, allowing queries to filter vault entries by visibility: public entries are shown to all users, while private entries are shown only to their owners.
* Updated the `PasswordVaultResource` resource to use the new visibility scope in its main query, retrieving the authenticated user’s ID via the `AuthService` and filtering accordingly.
* Imported the necessary `AuthService` and `Builder` classes to support these changes in the resource and model files. [[1]](diffhunk://#diff-4331a0746d71e1c1bd43a49b75da839ab2e332fd74dd019d4e630f28eadcbdb8R8) [[2]](diffhunk://#diff-3de620ed790af8205f6ae6f7b0d4d4497dd51b0a7c12635ceb1c9987605a182bR8)

><img width="1105" height="430" alt="image" src="https://github.com/user-attachments/assets/628f7e03-cad4-4a30-b9ef-12e16bb0e014" />
