### PR TITLE
feat: enhance password vault access control with user-specific permis…

### DIFF
--- a/app/Models/PasswordVault.php
+++ b/app/Models/PasswordVault.php
@@ -43,7 +43,31 @@ class PasswordVault extends Model
                 ->orWhere(function ($sub) use ($userId) {
                     $sub->where('type', 'private')
                         ->where('user_id', $userId);
+                })
+                ->orWhereHas('passwordShares', function ($sub) use ($userId) {
+                    $sub->where('shared_with', $userId);
                 });
         });
+    }
+
+    public function canView($userId)
+    {
+        if ($this->user_id == $userId) {
+            return true;
+        }
+        if ($this->type == 'public') {
+            return true;
+        }
+
+        return $this->passwordShares()->where('shared_with', $userId)->whereIn('permissions', ['view', 'edit'])->exists();
+    }
+
+    public function canEdit($userId)
+    {
+        if ($this->user_id == $userId) {
+            return true;
+        }
+
+        return $this->passwordShares()->where('shared_with', $userId)->where('permissions', 'edit')->exists();
     }
 }


### PR DESCRIPTION
This pull request enhances access control for password vault records by introducing per-user visibility checks for view and edit actions. The changes ensure that only authorized users can see and interact with records based on ownership, sharing permissions, and record type.

**Access control improvements:**

* Added `canView` and `canEdit` methods to the `PasswordVault` model to check if the current user can view or edit a record, considering ownership, public visibility, and sharing permissions.
* Updated the table actions in `PasswordVaultResource.php` to conditionally display view and edit options based on the user's permissions using the new methods.

**Codebase consistency and utility:**

* Refactored user ID retrieval by introducing a static `getAuthUserId` method and storing the authenticated user ID in the resource class for consistent access.
* Modified the query logic in `getEloquentQuery` and `scopeVisibleToUser` to include records shared with the user, ensuring comprehensive visibility according to sharing rules. [[1]](diffhunk://#diff-4331a0746d71e1c1bd43a49b75da839ab2e332fd74dd019d4e630f28eadcbdb8L172-R187) [[2]](diffhunk://#diff-3de620ed790af8205f6ae6f7b0d4d4497dd51b0a7c12635ceb1c9987605a182bR46-R72)…sions

><img width="1105" height="430" alt="image" src="https://github.com/user-attachments/assets/9269e25a-0f5f-457f-a8e8-49e80100a922" />
