### PR TITLE
feat: implement user-specific visibility for password sharing and enh…

### DIFF
--- a/app/Models/PasswordShare.php
+++ b/app/Models/PasswordShare.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 class PasswordShare extends Model
@@ -26,5 +27,10 @@ class PasswordShare extends Model
     public function sharedWith()
     {
         return $this->belongsTo(User::class, 'shared_with');
+    }
+
+    public function scopeVisibleToUser(Builder $query, $userId)
+    {
+        return $query->where('shared_by', $userId);
     }
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -290,5 +290,6 @@
     "view": "ver",
     "edit": "editar",
     "private": "privado",
-    "public": "público"
+    "public": "público",
+    "Request Information": "Registro de Tranferencia"
 }


### PR DESCRIPTION
This pull request enhances the password sharing feature by restricting data visibility and selection based on the authenticated user, improving both security and user experience. The main changes involve filtering selectable passwords and users, customizing query scopes, and updating language translations.

**Password sharing logic improvements:**

* Added `AuthService` integration to `PasswordShareResource`, enabling access to the authenticated user's ID for filtering purposes. [[1]](diffhunk://#diff-88a55e1d86e0a24c7fbc11e0e60e1c503bcd1a0555522d859079741a780a7e0aR8-R15) [[2]](diffhunk://#diff-88a55e1d86e0a24c7fbc11e0e60e1c503bcd1a0555522d859079741a780a7e0aR43-R54)
* Updated the password and user selection fields in the form to only display passwords owned by the authenticated user and users other than the authenticated user.

**Data access restrictions:**

* Introduced the `visibleToUser` query scope in `PasswordShare` to restrict visible records to those shared by the current user.
* Overrode the `getEloquentQuery` method in `PasswordShareResource` to apply the visibility scope for non-super users, ensuring users only see their own shared passwords.

**Localization update:**

* Updated the Spanish translation for "Request Information" to "Registro de Tranferencia" in `lang/es.json`.…ance Spanish translations

><img width="1353" height="614" alt="image" src="https://github.com/user-attachments/assets/3b5e9163-e407-4abd-8ef0-cedf53d046ca" />
