### PR TITLE
feat: add TimesheetImporter and integrate import action in TimesheetR…

### DIFF
--- a/app/Filament/Imports/TimesheetImporter.php
+++ b/app/Filament/Imports/TimesheetImporter.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Filament\Imports;
+
+use App\Models\Timesheet;
+use Filament\Actions\Imports\ImportColumn;
+use Filament\Actions\Imports\Importer;
+use Filament\Actions\Imports\Models\Import;
+
+class TimesheetImporter extends Importer
+{
+    protected static ?string $model = Timesheet::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            ImportColumn::make('calendar')
+                ->requiredMapping()
+                ->rules(['nullable']),
+            ImportColumn::make('staff_id')
+                ->requiredMapping()
+                ->numeric()
+                ->rules(['nullable']),
+            ImportColumn::make('user_id')
+                ->requiredMapping()
+                ->numeric()
+                ->rules(['nullable']),
+            ImportColumn::make('type')
+                ->requiredMapping()
+                ->rules(['nullable']),
+            ImportColumn::make('day_in')
+                ->requiredMapping()
+                ->rules(['nullable']),
+            ImportColumn::make('day_out')
+                ->requiredMapping()
+                ->rules(['nullable']),
+            ImportColumn::make('hours'),
+        ];
+    }
+
+    public function resolveRecord(): ?Timesheet
+    {
+        // return Timesheet::firstOrNew([
+        //     // Update existing records, matching them by `$this->data['column_name']`
+        //     'email' => $this->data['email'],
+        // ]);
+
+        return new Timesheet;
+    }
+
+    public static function getCompletedNotificationBody(Import $import): string
+    {
+        $body = 'Your timesheet import has completed and '.number_format($import->successful_rows).' '.str('row')->plural($import->successful_rows).' imported.';
+
+        if ($failedRowsCount = $import->getFailedRowsCount()) {
+            $body .= ' '.number_format($failedRowsCount).' '.str('row')->plural($failedRowsCount).' failed to import.';
+        }
+
+        return $body;
+    }
+}

--- a/app/Filament/Resources/TimesheetResource.php
+++ b/app/Filament/Resources/TimesheetResource.php
@@ -2,11 +2,13 @@
 
 namespace App\Filament\Resources;
 
+use App\Filament\Imports\TimesheetImporter;
 use App\Filament\Resources\TimesheetResource\Pages;
 use App\Models\Timesheet;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Actions\ImportAction;
 use Filament\Tables\Table;
 
 class TimesheetResource extends Resource
@@ -83,6 +85,11 @@ class TimesheetResource extends Resource
                 Tables\Actions\BulkActionGroup::make([
                     Tables\Actions\DeleteBulkAction::make(),
                 ]),
+            ])
+            ->headerActions([
+                ImportAction::make()
+                    ->importer(TimesheetImporter::class)
+                    ->icon('heroicon-o-arrow-up-tray'),
             ]);
     }
 


### PR DESCRIPTION
This pull request introduces a new import feature for timesheets in the Filament admin panel. The main change is the addition of a custom `TimesheetImporter` class, which enables bulk importing of timesheet data and provides user notifications on import completion. The `TimesheetResource` is updated to include an import action in its table header, allowing users to easily access the import functionality.

**Timesheet Import Feature:**

* Added a new `TimesheetImporter` class in `app/Filament/Imports/TimesheetImporter.php` to define the import columns, handle record resolution, and generate completion notifications for timesheet imports.
* Updated `TimesheetResource` (`app/Filament/Resources/TimesheetResource.php`) to register the new importer and display an import action in the table header using Filament's `ImportAction`. [[1]](diffhunk://#diff-7112ad16179382c12371420d69a22c018080d2b37dd2749f2ca6e9d0d9e9d0f8R5-R11) [[2]](diffhunk://#diff-7112ad16179382c12371420d69a22c018080d2b37dd2749f2ca6e9d0d9e9d0f8R88-R92)…esource

><img width="1090" height="524" alt="image" src="https://github.com/user-attachments/assets/9e5810da-7a0b-4525-a099-c5e47bbe9cd2" />
