### PR TITLE
feat: add HolidayImporter and integrate import action in HolidayResource

### DIFF
--- a/app/Filament/Imports/HolidayImporter.php
+++ b/app/Filament/Imports/HolidayImporter.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Filament\Imports;
+
+use App\Models\Holiday;
+use Filament\Actions\Imports\ImportColumn;
+use Filament\Actions\Imports\Importer;
+use Filament\Actions\Imports\Models\Import;
+
+class HolidayImporter extends Importer
+{
+    protected static ?string $model = Holiday::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            ImportColumn::make('calendar')
+                ->requiredMapping()
+                ->rules(['nullable']),
+            ImportColumn::make('staff_id')
+                ->requiredMapping()
+                ->numeric()
+                ->rules(['nullable']),
+            ImportColumn::make('user_id')
+                ->requiredMapping()
+                ->numeric()
+                ->rules(['nullable']),
+            ImportColumn::make('start_day')
+                ->requiredMapping()
+                ->rules(['nullable']),
+            ImportColumn::make('end_day')
+                ->requiredMapping()
+                ->rules(['nullable']),
+            ImportColumn::make('type')
+                ->requiredMapping()
+                ->rules(['nullable']),
+            ImportColumn::make('status')
+                ->requiredMapping()
+                ->rules(['nullable']),
+            ImportColumn::make('description')
+                ->requiredMapping()
+                ->rules(['nullable']),
+        ];
+    }
+
+    public function resolveRecord(): ?Holiday
+    {
+        // return Holiday::firstOrNew([
+        //     // Update existing records, matching them by `$this->data['column_name']`
+        //     'email' => $this->data['email'],
+        // ]);
+
+        return new Holiday;
+    }
+
+    public static function getCompletedNotificationBody(Import $import): string
+    {
+        $body = 'Your holiday import has completed and '.number_format($import->successful_rows).' '.str('row')->plural($import->successful_rows).' imported.';
+
+        if ($failedRowsCount = $import->getFailedRowsCount()) {
+            $body .= ' '.number_format($failedRowsCount).' '.str('row')->plural($failedRowsCount).' failed to import.';
+        }
+
+        return $body;
+    }
+}

--- a/app/Filament/Resources/HolidayResource.php
+++ b/app/Filament/Resources/HolidayResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Enums\HolidayTypeEnum;
+use App\Filament\Imports\HolidayImporter;
 use App\Filament\Resources\HolidayResource\Pages;
 use App\Models\Holiday;
 use Filament\Forms;
@@ -10,6 +11,7 @@ use Filament\Forms\Components\Section;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Actions\ImportAction;
 use Filament\Tables\Table;
 
 class HolidayResource extends Resource
@@ -112,6 +114,11 @@ class HolidayResource extends Resource
                 Tables\Actions\BulkActionGroup::make([
                     Tables\Actions\DeleteBulkAction::make(),
                 ]),
+            ])
+            ->headerActions([
+                ImportAction::make()
+                    ->importer(HolidayImporter::class)
+                    ->icon('heroicon-o-arrow-up-tray'),
             ]);
     }
 


### PR DESCRIPTION
This pull request introduces a new import feature for holidays, allowing users to bulk import holiday records via the Filament admin interface. The main changes include the creation of a dedicated importer class and integration of the import action into the holiday resource table.

### Holiday Import Feature

* Added a new `HolidayImporter` class in `app/Filament/Imports/HolidayImporter.php` to handle holiday record imports, including column mapping, validation rules, record resolution, and completion notifications.
* Integrated the `HolidayImporter` into the holiday resource table by importing the class and adding an `ImportAction` to the table's header actions in `app/Filament/Resources/HolidayResource.php`. This enables users to trigger holiday imports directly from the admin interface. [[1]](diffhunk://#diff-ac43e39391581516c6a162cca7f90e7a37df3fef665a24f8fe197ae924e06649R6-R14) [[2]](diffhunk://#diff-ac43e39391581516c6a162cca7f90e7a37df3fef665a24f8fe197ae924e06649R117-R121)


><img width="1090" height="524" alt="image" src="https://github.com/user-attachments/assets/7560c88f-e33e-4448-a43e-7fe008782e28" />
