### PR TITLE
feat: add PasswordShareImporter and integrate import action in Passwo…

### DIFF
--- a/app/Filament/Imports/PasswordShareImporter.php
+++ b/app/Filament/Imports/PasswordShareImporter.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Filament\Imports;
+
+use App\Models\PasswordShare;
+use Filament\Actions\Imports\ImportColumn;
+use Filament\Actions\Imports\Importer;
+use Filament\Actions\Imports\Models\Import;
+
+class PasswordShareImporter extends Importer
+{
+    protected static ?string $model = PasswordShare::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            ImportColumn::make('password_id')
+                ->requiredMapping()
+                ->numeric()
+                ->rules(['nullable']),
+            ImportColumn::make('shared_with')
+                ->requiredMapping()
+                ->numeric()
+                ->rules(['nullable']),
+            ImportColumn::make('shared_by')
+                ->requiredMapping()
+                ->numeric()
+                ->rules(['nullable']),
+            ImportColumn::make('permissions')
+                ->requiredMapping()
+                ->rules(['nullable']),
+        ];
+    }
+
+    public function resolveRecord(): ?PasswordShare
+    {
+        // return PasswordShare::firstOrNew([
+        //     // Update existing records, matching them by `$this->data['column_name']`
+        //     'email' => $this->data['email'],
+        // ]);
+
+        return new PasswordShare;
+    }
+
+    public static function getCompletedNotificationBody(Import $import): string
+    {
+        $body = 'Your password share import has completed and '.number_format($import->successful_rows).' '.str('row')->plural($import->successful_rows).' imported.';
+
+        if ($failedRowsCount = $import->getFailedRowsCount()) {
+            $body .= ' '.number_format($failedRowsCount).' '.str('row')->plural($failedRowsCount).' failed to import.';
+        }
+
+        return $body;
+    }
+}

--- a/app/Filament/Resources/PasswordShareResource.php
+++ b/app/Filament/Resources/PasswordShareResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Enums\PermissionsPasswordEnum;
+use App\Filament\Imports\PasswordShareImporter;
 use App\Filament\Resources\PasswordShareResource\Pages;
 use App\Models\PasswordShare;
 use App\Services\Auth\AuthService;
@@ -11,6 +12,7 @@ use Filament\Forms\Components\Section;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Actions\ImportAction;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -125,6 +127,11 @@ class PasswordShareResource extends Resource
                 Tables\Actions\BulkActionGroup::make([
                     Tables\Actions\DeleteBulkAction::make(),
                 ]),
+            ])
+            ->headerActions([
+                ImportAction::make()
+                    ->importer(PasswordShareImporter::class)
+                    ->icon('heroicon-o-arrow-up-tray'),
             ]);
     }
 


### PR DESCRIPTION
This pull request introduces a new import feature for password shares in the Filament admin panel. The main change is the addition of a custom importer for the `PasswordShare` model, allowing admins to bulk import password share records with validation and notifications for success or failure.

**Import Feature Additions:**

* Added a new `PasswordShareImporter` class that defines import columns, validation rules, record resolution, and custom completion notifications for password share imports (`app/Filament/Imports/PasswordShareImporter.php`).
* Integrated the import action into the `PasswordShareResource` table, enabling users to import password shares directly from the resource UI with a dedicated icon (`app/Filament/Resources/PasswordShareResource.php`). [[1]](diffhunk://#diff-88a55e1d86e0a24c7fbc11e0e60e1c503bcd1a0555522d859079741a780a7e0aR6) [[2]](diffhunk://#diff-88a55e1d86e0a24c7fbc11e0e60e1c503bcd1a0555522d859079741a780a7e0aR15) [[3]](diffhunk://#diff-88a55e1d86e0a24c7fbc11e0e60e1c503bcd1a0555522d859079741a780a7e0aR130-R134)…rdShareResource

><img width="1090" height="524" alt="image" src="https://github.com/user-attachments/assets/e9282221-ca23-4576-861e-a21cd2bc8708" />
