### PR TITLE
feat: add HolidayExporter and integrate export action in HolidayResource

### DIFF
--- a/app/Filament/Exports/HolidayExporter.php
+++ b/app/Filament/Exports/HolidayExporter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Filament\Exports;
+
+use App\Models\Holiday;
+use Filament\Actions\Exports\ExportColumn;
+use Filament\Actions\Exports\Exporter;
+use Filament\Actions\Exports\Models\Export;
+
+class HolidayExporter extends Exporter
+{
+    protected static ?string $model = Holiday::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            ExportColumn::make('id')
+                ->label('ID'),
+            ExportColumn::make('calendar'),
+            ExportColumn::make('staff_id'),
+            ExportColumn::make('user_id'),
+            ExportColumn::make('start_day'),
+            ExportColumn::make('end_day'),
+            ExportColumn::make('type'),
+            ExportColumn::make('status'),
+            ExportColumn::make('description'),
+            ExportColumn::make('created_at'),
+            ExportColumn::make('updated_at'),
+        ];
+    }
+
+    public static function getCompletedNotificationBody(Export $export): string
+    {
+        $body = 'Your holiday export has completed and '.number_format($export->successful_rows).' '.str('row')->plural($export->successful_rows).' exported.';
+
+        if ($failedRowsCount = $export->getFailedRowsCount()) {
+            $body .= ' '.number_format($failedRowsCount).' '.str('row')->plural($failedRowsCount).' failed to export.';
+        }
+
+        return $body;
+    }
+}

--- a/app/Filament/Resources/HolidayResource.php
+++ b/app/Filament/Resources/HolidayResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Enums\HolidayTypeEnum;
+use App\Filament\Exports\HolidayExporter;
 use App\Filament\Imports\HolidayImporter;
 use App\Filament\Resources\HolidayResource\Pages;
 use App\Models\Holiday;
@@ -11,6 +12,7 @@ use Filament\Forms\Components\Section;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Actions\ExportBulkAction;
 use Filament\Tables\Actions\ImportAction;
 use Filament\Tables\Table;
 
@@ -112,6 +114,8 @@ class HolidayResource extends Resource
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
+                    ExportBulkAction::make()
+                        ->exporter(HolidayExporter::class),
                     Tables\Actions\DeleteBulkAction::make(),
                 ]),
             ])


### PR DESCRIPTION
This pull request introduces a new export feature for holidays and integrates it into the Filament admin resource for holidays. The main change is the addition of a custom exporter class and its registration as a bulk action, allowing users to export holiday data directly from the admin interface.

**Holiday Export Feature Integration:**

* Added new `HolidayExporter` class to handle exporting holiday data, including specifying export columns and a custom notification message for completed exports.
* Registered the `HolidayExporter` as an export bulk action in the `HolidayResource` table, enabling bulk export functionality for holidays in the admin panel.

**Dependency and Import Updates:**

* Imported `HolidayExporter` in `HolidayResource.php` to support the new export functionality.
* Imported `ExportBulkAction` in `HolidayResource.php` for registering the export bulk action.

><img width="1090" height="524" alt="image" src="https://github.com/user-attachments/assets/6ea5e591-86fd-4b49-9664-935f7325d20c" />
