### PR TITLE
feat: add PasswordShareExporter and integrate export action in Passwo…

### DIFF
--- a/app/Filament/Exports/PasswordShareExporter.php
+++ b/app/Filament/Exports/PasswordShareExporter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Filament\Exports;
+
+use App\Models\PasswordShare;
+use Filament\Actions\Exports\ExportColumn;
+use Filament\Actions\Exports\Exporter;
+use Filament\Actions\Exports\Models\Export;
+
+class PasswordShareExporter extends Exporter
+{
+    protected static ?string $model = PasswordShare::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            ExportColumn::make('id'),
+            ExportColumn::make('shared_with'),
+            ExportColumn::make('shared_by'),
+            ExportColumn::make('permissions'),
+            ExportColumn::make('created_at'),
+            ExportColumn::make('updated_at'),
+        ];
+    }
+
+    public static function getCompletedNotificationBody(Export $export): string
+    {
+        $body = 'Your password share export has completed and '.number_format($export->successful_rows).' '.str('row')->plural($export->successful_rows).' exported.';
+
+        if ($failedRowsCount = $export->getFailedRowsCount()) {
+            $body .= ' '.number_format($failedRowsCount).' '.str('row')->plural($failedRowsCount).' failed to export.';
+        }
+
+        return $body;
+    }
+}

--- a/app/Filament/Resources/PasswordShareResource.php
+++ b/app/Filament/Resources/PasswordShareResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Enums\PermissionsPasswordEnum;
+use App\Filament\Exports\PasswordShareExporter;
 use App\Filament\Imports\PasswordShareImporter;
 use App\Filament\Resources\PasswordShareResource\Pages;
 use App\Models\PasswordShare;
@@ -12,6 +13,7 @@ use Filament\Forms\Components\Section;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Actions\ExportBulkAction;
 use Filament\Tables\Actions\ImportAction;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -125,6 +127,8 @@ class PasswordShareResource extends Resource
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
+                    ExportBulkAction::make()
+                        ->exporter(PasswordShareExporter::class),
                     Tables\Actions\DeleteBulkAction::make(),
                 ]),
             ])


### PR DESCRIPTION
This pull request introduces export functionality for password shares in the Filament admin panel. The main change is the addition of a new exporter class, along with updates to the resource to support bulk export actions.

**Export functionality additions:**

* Added the new `PasswordShareExporter` class in `app/Filament/Exports/PasswordShareExporter.php`, which defines export columns and a custom notification message for completed exports.
* Registered the exporter in `PasswordShareResource` by importing `PasswordShareExporter` and adding an `ExportBulkAction` to the bulk actions group, enabling users to export password shares directly from the resource table. [[1]](diffhunk://#diff-88a55e1d86e0a24c7fbc11e0e60e1c503bcd1a0555522d859079741a780a7e0aR6) [[2]](diffhunk://#diff-88a55e1d86e0a24c7fbc11e0e60e1c503bcd1a0555522d859079741a780a7e0aR16) [[3]](diffhunk://#diff-88a55e1d86e0a24c7fbc11e0e60e1c503bcd1a0555522d859079741a780a7e0aR130-R131)…rdShareResource


><img width="1090" height="524" alt="image" src="https://github.com/user-attachments/assets/bf68a691-0779-4fe3-afd2-07619c3d7b58" />
