### PR TITLE
fix: Correct route names in optionsAccess for consistency

### DIFF
--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -16,13 +16,13 @@
     const optionsAccess = [
         {
             name: 'Asistencias',
-            route: 'TimeSheet',
+            route: 'timesheet',
             background:
                 'https://i.pinimg.com/736x/ce/c4/b3/cec4b3cc815353d62435bb666868594a.jpg',
         },
         {
             name: 'Contraseñas',
-            route: 'PasswordsVault',
+            route: 'password-vault',
             background:
                 'https://i.pinimg.com/736x/ae/48/4a/ae484a15a84631934a735e96ad73147d.jpg',
         },


### PR DESCRIPTION
This pull request makes minor updates to the route names in the dashboard options to use consistent lowercase and hyphenated formats.

* Updated the `route` property in the dashboard options for "Asistencias" from `TimeSheet` to `timesheet`, and for "Contraseñas" from `PasswordsVault` to `password-vault` in `Dashboard.vue` for improved route naming consistency.