### PR TITLE
feat: Add ThrottlingModal component for handling login attempt limits

### DIFF
--- a/resources/js/Components/Modals/ThrottlingModal.vue
+++ b/resources/js/Components/Modals/ThrottlingModal.vue
@@ -1,0 +1,63 @@
+<script setup>
+    import DialogModal from '@/Components/Modals/DialogModal.vue';
+
+    defineProps({
+        show: {
+            type: Boolean,
+            default: false,
+        },
+    });
+
+    const emit = defineEmits(['close']);
+
+    const closeModal = () => {
+        emit('close');
+    };
+</script>
+
+<template>
+    <DialogModal
+        :show="show"
+        @close="closeModal"
+        maxWidth="sm"
+        class="bg-white rounded-lg shadow-lg animate-fade-in"
+    >
+        <template #title>
+            <h3 class="text-lg font-semibold text-gray-800">
+                Demasiados Intentos
+            </h3>
+        </template>
+        <template #content>
+            <p class="text-sm text-gray-600">
+                Has realizado demasiados intentos de inicio de sesión. Por
+                favor, espera unos minutos antes de intentarlo de nuevo.
+            </p>
+        </template>
+        <template #footer>
+            <button
+                @click="closeModal"
+                class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition duration-200"
+            >
+                Entendido
+            </button>
+        </template>
+    </DialogModal>
+</template>
+
+<style scoped>
+    /* Animación para el modal */
+    .animate-fade-in {
+        animation: fadeIn 0.5s ease-in-out;
+    }
+
+    @keyframes fadeIn {
+        from {
+            opacity: 0;
+            transform: scale(0.9);
+        }
+        to {
+            opacity: 1;
+            transform: scale(1);
+        }
+    }
+</style>


### PR DESCRIPTION
This pull request introduces a new modal component to handle user login throttling feedback. The `ThrottlingModal.vue` provides a user-friendly dialog that informs users when they have made too many login attempts and need to wait before trying again.

New modal component for throttling feedback:

* Added `ThrottlingModal.vue` with a dialog that displays a message about excessive login attempts and prompts users to wait before retrying. The modal includes a close button and a fade-in animation for improved user experience.

><img width="693" height="629" alt="image" src="https://github.com/user-attachments/assets/af05f06d-ce4a-4a7f-a802-b3de9c4c0546" />
