### PR TITLE
feat: Enhance Timesheet functionality with type selection and improve…

### DIFF
--- a/app/Http/Controllers/TimesheetController.php
+++ b/app/Http/Controllers/TimesheetController.php
@@ -110,6 +110,7 @@ class TimesheetController extends Controller
 
     public function scan(Request $request)
     {
+        dd($request->all());
         $this->timesheetService->storeData($request->all());
 
         return redirect()->route('timesheets.list')->banner('Asistencia Actualizada');

--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -84,4 +84,14 @@ class Timesheet extends Model
 
         return $query;
     }
+
+    public function scopeForStaffAndDate(Builder $query, $staffId, $currentDate)
+    {
+        return $query->where('staff_id', $staffId)->whereDate('day_in', $currentDate);
+    }
+
+    public function scopeOpen(Builder $query)
+    {
+        return $query->whereNull('day_out');
+    }
 }

--- a/app/Repositories/Models/TimesheetRepository.php
+++ b/app/Repositories/Models/TimesheetRepository.php
@@ -94,7 +94,7 @@ class TimesheetRepository extends BaseRepository
                 'day_in' => $currentDate.' '.$currentTime,
                 'day_out' => null,
                 'hours' => 0,
-                'type' => 'work',
+                'type' => $data['type'] ?? 'work',
             ]);
         } else {
             if (! $timesheet->day_out) {

--- a/app/Repositories/Models/TimesheetRepository.php
+++ b/app/Repositories/Models/TimesheetRepository.php
@@ -75,42 +75,6 @@ class TimesheetRepository extends BaseRepository
         ];
     }
 
-    public function storeData(array $data)
-    {
-        $qrData = $data['qr_data'] ?? null;
-        $staffId = $this->extractIdFromQr($qrData);
-        $userId = $this->userService->getAuthUserId();
-        $currentDate = Carbon::now()->toDateString();
-        $currentTime = Carbon::now()->toTimeString();
-        $timesheet = $this->model->where('staff_id', $staffId)
-            ->whereDate('day_in', $currentDate)
-            ->first();
-
-        if (! $timesheet) {
-            $timesheet = $this->model->create([
-                'user_id' => $userId,
-                'staff_id' => $staffId,
-                'calendar' => Carbon::now()->year,
-                'day_in' => $currentDate.' '.$currentTime,
-                'day_out' => null,
-                'hours' => 0,
-                'type' => $data['type'] ?? 'work',
-            ]);
-        } else {
-            if (! $timesheet->day_out) {
-                $dayOut = $currentDate.' '.$currentTime;
-                $hours = Carbon::parse($timesheet->day_in)->diffInHours(Carbon::parse($dayOut)) +
-                    (Carbon::parse($timesheet->day_in)->diffInMinutes(Carbon::parse($dayOut)) % 60) / 60;
-                $timesheet->update([
-                    'day_out' => $dayOut,
-                    'hours' => round($hours, 2),
-                ]);
-            }
-        }
-
-        return $timesheet;
-    }
-
     private function extractIdFromQr(string $qrData): ?string
     {
         $lines = explode("\n", trim($qrData));
@@ -121,5 +85,86 @@ class TimesheetRepository extends BaseRepository
         }
 
         return null;
+    }
+
+    private function prepareData(array $data): array
+    {
+        $qrData = $data['qr_data'] ?? null;
+        $staffId = $this->extractIdFromQr($qrData);
+        $userId = $this->userService->getAuthUserId();
+        $currentDate = Carbon::now()->toDateString();
+        $currentTime = Carbon::now()->toTimeString();
+        $newType = $data['type'] ?? 'work';
+
+        return [
+            'staffId' => $staffId,
+            'userId' => $userId,
+            'currentDate' => $currentDate,
+            'currentTime' => $currentTime,
+            'newType' => $newType,
+        ];
+    }
+
+    private function handleTimesheetLogic(array $prepared): Timesheet
+    {
+        $staffId = $prepared['staffId'];
+        $userId = $prepared['userId'];
+        $currentDate = $prepared['currentDate'];
+        $currentTime = $prepared['currentTime'];
+        $newType = $prepared['newType'];
+
+        $openTimesheet = $this->model->forStaffAndDate($staffId, $currentDate)->open()->first();
+
+        if ($openTimesheet) {
+            if ($openTimesheet->type === $newType) {
+                $dayOut = $currentDate.' '.$currentTime;
+                $hours = Carbon::parse($openTimesheet->day_in)->diffInHours(Carbon::parse($dayOut)) +
+                    (Carbon::parse($openTimesheet->day_in)->diffInMinutes(Carbon::parse($dayOut)) % 60) / 60;
+                $openTimesheet->update([
+                    'day_out' => $dayOut,
+                    'hours' => round($hours, 2),
+                ]);
+
+                return $openTimesheet;
+            } else {
+                $dayOut = $currentDate.' '.$currentTime;
+                $hours = Carbon::parse($openTimesheet->day_in)->diffInHours(Carbon::parse($dayOut)) +
+                    (Carbon::parse($openTimesheet->day_in)->diffInMinutes(Carbon::parse($dayOut)) % 60) / 60;
+                $openTimesheet->update([
+                    'day_out' => $dayOut,
+                    'hours' => round($hours, 2),
+                ]);
+                $timesheet = $this->model->create([
+                    'user_id' => $userId,
+                    'staff_id' => $staffId,
+                    'calendar' => Carbon::now()->year,
+                    'day_in' => $currentDate.' '.$currentTime,
+                    'day_out' => null,
+                    'hours' => 0,
+                    'type' => $newType,
+                ]);
+
+                return $timesheet;
+            }
+        } else {
+            $timesheet = $this->model->create([
+                'user_id' => $userId,
+                'staff_id' => $staffId,
+                'calendar' => Carbon::now()->year,
+                'day_in' => $currentDate.' '.$currentTime,
+                'day_out' => null,
+                'hours' => 0,
+                'type' => $newType,
+            ]);
+
+            return $timesheet;
+        }
+    }
+
+    public function storeData(array $data): Timesheet
+    {
+        $prepared = $this->prepareData($data);
+
+        return $this->handleTimesheetLogic($prepared);
     }
 }

--- a/resources/js/Components/Inputs/InputSelectClasic.vue
+++ b/resources/js/Components/Inputs/InputSelectClasic.vue
@@ -394,7 +394,7 @@
             v-if="showDropdown"
             :id="'dropdown-' + _uid"
             :class="[
-                'absolute z-50 mt-1 w-full bg-white rounded-md shadow-lg max-h-60 overflow-auto select-dropdown',
+                'absolute z-[9999] mt-1 w-full bg-white rounded-md shadow-lg max-h-60 overflow-auto select-dropdown',
                 themeClasses.dropdownBorder,
             ]"
             role="listbox"

--- a/resources/js/Components/TimeSheets/ModalQrScanner.vue
+++ b/resources/js/Components/TimeSheets/ModalQrScanner.vue
@@ -7,6 +7,7 @@
     import Modal from '../Modals/Modal.vue';
     import InputError from '../Inputs/InputError.vue';
     import LoadPoints from '@/Components/Icons/LoadPoints.vue';
+    import InputSelectClasic from '../Inputs/InputSelectClasic.vue';
 
     const props = defineProps({
         show: {
@@ -21,6 +22,7 @@
     const error = ref('');
     const cameraError = ref('');
     const loading = ref(false);
+    const selectedCamera = ref('work');
 
     watch(
         () => props.show,
@@ -38,7 +40,7 @@
             loading.value = false;
             router.post(
                 route('scan'),
-                { qr_data: result },
+                { qr_data: result, type: selectedCamera.value },
                 {
                     onSuccess: () => {
                         emit('close');
@@ -56,6 +58,10 @@
     };
 
     const startScanning = () => {
+        if (!selectedCamera.value) {
+            error.value = 'Selecciona un tipo antes de escanear.';
+            return;
+        }
         scanning.value = true;
         error.value = '';
         cameraError.value = '';
@@ -75,7 +81,7 @@
 
 <template>
     <Modal :show="props.show" @close="closeModal" maxWidth="md">
-        <div class="p-4 sm:p-6 lg:p-8">
+        <div class="p-6 sm:p-6 lg:p-8">
             <div class="flex justify-between items-center mb-4">
                 <h2
                     class="text-lg sm:text-xl lg:text-2xl font-semibold text-gray-800"
@@ -92,17 +98,34 @@
 
             <div class="qr-scanner">
                 <div
-                    class="flex flex-col sm:flex-row gap-2 p-4 justify-center mb-4"
+                    class="flex flex-col sm:flex-row gap-2 p-2 justify-center mb-4"
                 >
-                    <ClasicButton
-                        @click="startScanning"
-                        :disabled="scanning"
-                        variant="blue"
-                        class="w-full sm:w-auto flex justify-center"
+                    <div
+                        class="flex flex-col sm:flex-col gap-2 w-full sm:w-[200px]"
                     >
-                        <LoadPoints v-if="scanning" :variant="'white'" />
-                        <span v-else>Iniciar Escaneo</span>
-                    </ClasicButton>
+                        <InputSelectClasic
+                            v-if="!scanning"
+                            v-model="selectedCamera"
+                            :options="[
+                                { id: 'work', text: 'Trabajo' },
+                                { id: 'break', text: 'Descanso' },
+                            ]"
+                            placeholder="Tipo"
+                            theme="gray"
+                            :required="true"
+                            :CleanButton="true"
+                            class="w-full sm:w-auto"
+                        />
+                        <ClasicButton
+                            @click="startScanning"
+                            :disabled="scanning"
+                            variant="blue"
+                            class="w-full sm:w-auto flex justify-center"
+                        >
+                            <LoadPoints v-if="scanning" :variant="'white'" />
+                            <span v-else>Iniciar Escaneo</span>
+                        </ClasicButton>
+                    </div>
                     <ClasicButton
                         v-if="scanning"
                         @click="stopScanning"

--- a/resources/js/Pages/PasswordVault/List.vue
+++ b/resources/js/Pages/PasswordVault/List.vue
@@ -49,8 +49,8 @@
 
 <template>
     <AppLayout title="Password Vault">
-        <section class="mx-auto px-4 sm:px-6 lg:px-8 py-6 w-full max-w-7xl">
-            <div class="flex flex-col gap-6 mt-4">
+        <section class="mx-auto px-4 sm:px-6 lg:px-8 py-2 w-full max-w-7xl">
+            <div class="flex flex-col gap-4 mt-1">
                 <!-- Filtros -->
                 <div class="bg-white shadow-lg rounded-lg p-4 md:p-6">
                     <div

--- a/resources/js/Pages/TimeSheet/List.vue
+++ b/resources/js/Pages/TimeSheet/List.vue
@@ -95,8 +95,8 @@
 
 <template>
     <AppLayout title="Timesheets">
-        <section class="mx-auto px-4 sm:px-6 lg:px-8 py-6 w-full max-w-7xl">
-            <div class="flex flex-col gap-6 mt-6">
+        <section class="mx-auto px-4 sm:px-6 lg:px-8 py-2 w-full max-w-7xl">
+            <div class="flex flex-col gap-4 mt-1">
                 <!-- Filters Section -->
                 <div class="bg-white shadow-lg rounded-xl p-6">
                     <div


### PR DESCRIPTION
This pull request introduces a new feature to the QR scanner modal for timesheets, allowing users to select the type of scan (e.g., "work" or "break") before scanning. The selected type is now sent to the backend and stored in the timesheet record. Additionally, there are minor UI improvements to dropdown z-index and page padding.

**Feature: Timesheet scan type selection**
* Added an `InputSelectClasic` dropdown to `ModalQrScanner.vue` so users can select a scan type ("Trabajo" or "Descanso") before scanning. Scanning is disabled until a type is selected, and the selected type is sent with the QR data to the backend. [[1]](diffhunk://#diff-5a8a58202417f2a6d42b5d507ecc4742d582686ab5ac3a67b70981dccb3a41d5R10) [[2]](diffhunk://#diff-5a8a58202417f2a6d42b5d507ecc4742d582686ab5ac3a67b70981dccb3a41d5R25) [[3]](diffhunk://#diff-5a8a58202417f2a6d42b5d507ecc4742d582686ab5ac3a67b70981dccb3a41d5L41-R43) [[4]](diffhunk://#diff-5a8a58202417f2a6d42b5d507ecc4742d582686ab5ac3a67b70981dccb3a41d5R61-R64) [[5]](diffhunk://#diff-5a8a58202417f2a6d42b5d507ecc4742d582686ab5ac3a67b70981dccb3a41d5L95-R118) [[6]](diffhunk://#diff-5a8a58202417f2a6d42b5d507ecc4742d582686ab5ac3a67b70981dccb3a41d5R128)
* Updated the backend to store the selected scan type in the timesheet record, defaulting to "work" if none is provided. (`TimesheetRepository.php`)

**UI Improvements**
* Increased the z-index of the dropdown in `InputSelectClasic.vue` to ensure it appears above other elements.
* Reduced padding and gaps in the timesheet and password vault list pages for a more compact UI. (`List.vue` files) [[1]](diffhunk://#diff-4a9990a5d2fc19341d4910c22ae7d1e99f4339fb341a07486b54da72e52f1453L52-R53) [[2]](diffhunk://#diff-4c9aafc491e2bead9389afb62ec64dc4ed53817bec3054c99d6f3df1bd5a5bc5L98-R99)

**Debugging**
* Added a temporary `dd($request->all())` call in the `scan` method of `TimesheetController.php` for debugging incoming request data.… UI spacing