### PR TITLE
feat: Integrate torch toggle functionality in QR scanner and update m…

### DIFF
--- a/resources/js/Components/TimeSheets/ModalQrScanner.vue
+++ b/resources/js/Components/TimeSheets/ModalQrScanner.vue
@@ -8,6 +8,8 @@
     import InputError from '../Inputs/InputError.vue';
     import LoadPoints from '@/Components/Icons/LoadPoints.vue';
     import InputSelectClasic from '../Inputs/InputSelectClasic.vue';
+    import Bulb from '@/Components/Icons/Bulb.vue';
+    import BulbOff from '@/Components/Icons/BulbOff.vue';
 
     const props = defineProps({
         show: {
@@ -23,6 +25,10 @@
     const cameraError = ref('');
     const loading = ref(false);
     const selectedCamera = ref('work');
+    const torchEnabled = ref(false);
+    const toggleTorch = () => {
+        torchEnabled.value = !torchEnabled.value;
+    };
 
     watch(
         () => props.show,
@@ -132,7 +138,16 @@
                         variant="danger"
                         class="w-full sm:w-auto flex justify-center"
                     >
-                        Detener Escaneo
+                        Detener
+                    </ClasicButton>
+                    <ClasicButton
+                        v-if="scanning"
+                        @click="toggleTorch"
+                        variant="gray"
+                        class="w-full sm:w-auto flex justify-center items-center"
+                    >
+                        <Bulb v-if="!torchEnabled" class="w-5 h-5" />
+                        <BulbOff v-else class="w-5 h-5" />
                     </ClasicButton>
                 </div>
                 <div v-if="scanning" class="mt-4 relative">
@@ -146,7 +161,7 @@
                         @detect="onDetect"
                         @error="onError"
                         :formats="['qr_code']"
-                        :torch="false"
+                        :torch="torchEnabled"
                         class="rounded-lg border border-gray-300 shadow-md w-full max-w-xs sm:max-w-md lg:max-w-lg mx-auto"
                     />
                     <InputError class="mt-2 text-center text-sm sm:text-base">

--- a/resources/js/Pages/TimeSheet/List.vue
+++ b/resources/js/Pages/TimeSheet/List.vue
@@ -9,7 +9,7 @@
     import DateRangeFilter from '@/Components/Sections/SectionDateRangeFilter.vue';
     import InputSelectClasic from '@/Components/Inputs/InputSelectClasic.vue';
     import ModalQrGenerate from '@/Components/TimeSheets/ModalQrGenerate.vue';
-    import ModalScanerTest from '@/Components/TimeSheets/ModalScanerTest.vue';
+    import ModalQrScanner from '@/Components/TimeSheets/ModalQrScanner.vue';
 
     const props = defineProps({
         timesheets: {
@@ -310,6 +310,6 @@
             :qr-code="qrCode"
             @close="showQrModal = false"
         />
-        <ModalScanerTest :show="showScanner" @close="showScanner = false" />
+        <ModalQrScanner :show="showScanner" @close="showScanner = false" />
     </AppLayout>
 </template>


### PR DESCRIPTION
This pull request updates the QR code scanner modal in the timesheet feature to improve usability and add new functionality. The main enhancement is the addition of a torch (flashlight) toggle button to the QR scanner, allowing users to enable or disable the camera flash when scanning QR codes. Additionally, the modal component reference has been updated to use the correct scanner component.

**QR Scanner Modal Improvements:**

* Added torch (flashlight) toggle functionality to the QR scanner modal, including new state management (`torchEnabled`) and a toggle button that switches between `Bulb` and `BulbOff` icons. [[1]](diffhunk://#diff-5a8a58202417f2a6d42b5d507ecc4742d582686ab5ac3a67b70981dccb3a41d5R28-R31) [[2]](diffhunk://#diff-5a8a58202417f2a6d42b5d507ecc4742d582686ab5ac3a67b70981dccb3a41d5L135-R150)
* Modified the QR scanner to use the current `torchEnabled` state for the `torch` prop, enabling or disabling the camera flash as needed.

**Component Reference Updates:**

* Replaced references to `ModalScanerTest` with `ModalQrScanner` in the timesheet list page to ensure the correct modal is used for QR scanning. [[1]](diffhunk://#diff-4c9aafc491e2bead9389afb62ec64dc4ed53817bec3054c99d6f3df1bd5a5bc5L12-R12) [[2]](diffhunk://#diff-4c9aafc491e2bead9389afb62ec64dc4ed53817bec3054c99d6f3df1bd5a5bc5L313-R313)

**Icon Imports:**

* Imported new `Bulb` and `BulbOff` icons for use in the torch toggle button in the QR scanner modal.…odal reference in TimeSheet list

><img width="498" height="429" alt="image" src="https://github.com/user-attachments/assets/83aea1f9-0f56-41db-9ad7-ce024757532f" />
