### PR TITLE
feat: Add polling functionality to refresh timesheet data

### DIFF
--- a/resources/js/Pages/TimeSheet/List.vue
+++ b/resources/js/Pages/TimeSheet/List.vue
@@ -3,7 +3,7 @@
     import AppLayout from '@/Layouts/AppLayout.vue';
     import ClasicButton from '@/Components/Buttons/ClasicButton.vue';
     import { ref } from 'vue';
-    import { router } from '@inertiajs/vue3';
+    import { router, usePoll } from '@inertiajs/vue3';
     import Edit from '@/Components/Buttons/Edit.vue';
     import InputListSearch from '@/Components/Inputs/InputListSearch.vue';
     import DateRangeFilter from '@/Components/Sections/SectionDateRangeFilter.vue';
@@ -55,6 +55,7 @@
         text: staff.name || 'Sin nombre',
     }));
 
+    usePoll(5000, { only: ['timesheets'] });
     function handleSearch(val) {
         if (typeof val === 'object' && val !== null) {
             dateRange.value = val;


### PR DESCRIPTION
This pull request introduces a small enhancement to the timesheet listing page by enabling automatic data refresh. The change uses polling to keep the timesheet data up-to-date without requiring manual page reloads.

* Added `usePoll` from `@inertiajs/vue3` and configured it to poll every 5 seconds, refreshing only the `timesheets` data on the page. [[1]](diffhunk://#diff-4c9aafc491e2bead9389afb62ec64dc4ed53817bec3054c99d6f3df1bd5a5bc5L6-R6) [[2]](diffhunk://#diff-4c9aafc491e2bead9389afb62ec64dc4ed53817bec3054c99d6f3df1bd5a5bc5R58)

><img width="1227" height="406" alt="image" src="https://github.com/user-attachments/assets/a6e3869c-658c-4006-8957-82705a07a133" />
