### PR TITLE
137 mostrar solo las asistencias del usuario actual para el personal staff

### DIFF
--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -94,4 +94,9 @@ class Timesheet extends Model
     {
         return $query->whereNull('day_out');
     }
+
+    public function scopeFilterByUserAccess(Builder $query, $userId)
+    {
+        return $query->where('staff_id', $userId);
+    }
 }

--- a/app/Repositories/Models/TimesheetRepository.php
+++ b/app/Repositories/Models/TimesheetRepository.php
@@ -25,6 +25,11 @@ class TimesheetRepository extends BaseRepository
     public function getModel($search = null, $startDate = null, $endDate = null, $staffId = null, $perPage = 5)
     {
         $query = $this->model->withStaffProfile();
+
+        if ($this->userService->getAuthUser()->hasRole('Staff')) {
+            $query->filterByUserAccess($this->userService->getAuthUserId());
+        }
+
         if ($search || $startDate || $endDate || $staffId) {
             $query->searchData($search, $startDate, $endDate, $staffId);
         }

--- a/resources/js/Components/Inputs/InputSelectClasic.vue
+++ b/resources/js/Components/Inputs/InputSelectClasic.vue
@@ -2,6 +2,7 @@
     import { computed, ref, watch, onBeforeUnmount } from 'vue';
     import XIcon from '@/Components/Icons/XIcon.vue';
     import ClassicLabel from '../Labels/ClassicLabel.vue';
+    import { usePage } from '@inertiajs/vue3';
 
     const props = defineProps({
         modelValue: [String, Number, Array],
@@ -18,6 +19,14 @@
         initialValue: {
             type: [String, Number, Object],
             default: null,
+        },
+        roles: {
+            type: Array,
+            default: () => [],
+        },
+        permissions: {
+            type: Array,
+            default: () => [],
         },
     });
 
@@ -305,10 +314,23 @@
         emit('update:modelValue', '');
         emit('change', '');
     }
+
+    const hasAccess = computed(() => {
+        const user = usePage().props.auth?.user;
+        if (!user) return false;
+        if (!props.roles.length && !props.permissions.length) return true;
+
+        return (
+            props.roles.some(role => user.roles.includes(role)) ||
+            props.permissions.some(permission =>
+                user.permissions.includes(permission)
+            )
+        );
+    });
 </script>
 
 <template>
-    <div class="gap-1 relative w-full" ref="selectRef">
+    <div v-if="hasAccess" class="gap-1 relative w-full" ref="selectRef">
         <ClassicLabel
             v-if="label"
             :value="label"

--- a/resources/js/Pages/TimeSheet/List.vue
+++ b/resources/js/Pages/TimeSheet/List.vue
@@ -128,6 +128,8 @@
                                 id: props.staffId,
                                 text: selectedStaffText,
                             }"
+                            :roles="['super usuario', 'super_admin']"
+                            :permissions="[]"
                             label="Colaboradores"
                             placeholder="Colaborador"
                             :disabled="false"
@@ -311,6 +313,7 @@
                         </table>
                     </div>
                     <div
+                        v-if="timesheets.data?.length > 4"
                         class="mt-6 flex flex-col sm:flex-row items-center justify-between gap-4"
                     >
                         <PerPageSelector


### PR DESCRIPTION
This pull request introduces role-based access control to the `InputSelectClasic` Vue component and restricts timesheet data visibility for staff users. The main changes include adding new access control props and logic to the input component, updating its usage in the timesheet list page, and enforcing user-based filtering in backend queries.

**Role-based access control for UI components:**

* Added `roles` and `permissions` props to the `InputSelectClasic.vue` component, along with logic to conditionally render the input based on the authenticated user's roles and permissions. [[1]](diffhunk://#diff-c5a5ab5d8886b4f5627a3c3006c287220c6cb3f3033adc6f111f4843033e2694R23-R30) [[2]](diffhunk://#diff-c5a5ab5d8886b4f5627a3c3006c287220c6cb3f3033adc6f111f4843033e2694R317-R333)
* Updated the import statements in `InputSelectClasic.vue` to include `usePage` from `@inertiajs/vue3` for accessing user data.

**Backend query filtering for staff users:**

* Added a new query scope `scopeFilterByUserAccess` to the `Timesheet` model, enabling filtering timesheets by the authenticated user's staff ID.
* Updated the `TimesheetRepository` to apply this new filter automatically for users with the 'Staff' role, restricting their access to only their own timesheet records.

**UI usage updates:**

* Updated the usage of `InputSelectClasic` in `TimeSheet/List.vue` to restrict its visibility to users with the 'super usuario' or 'super_admin' roles.
* Added a conditional rendering for pagination controls in the timesheet list page, showing them only when there are more than four timesheet records.

><img width="1152" height="604" alt="image" src="https://github.com/user-attachments/assets/8849ef93-1230-4e44-bd5c-56f0de888e74" />
