### PR TITLE
feat: Implement user access filtering in PasswordVault and update Pas…

### DIFF
--- a/app/Models/PasswordVault.php
+++ b/app/Models/PasswordVault.php
@@ -112,4 +112,16 @@ class PasswordVault extends Model
 
         return $query;
     }
+
+    public function scopeFilterByUserAccess(Builder $query, $userId)
+    {
+        return $query->where(function ($query) use ($userId) {
+            $query->where('type', 'public')
+                ->orWhere('user_id', $userId)
+                ->orWhereHas('passwordShares', function ($query) use ($userId) {
+                    $query->where('shared_with', $userId)
+                        ->whereIn('permissions', ['view', 'edit']);
+                });
+        });
+    }
 }

--- a/app/Repositories/Models/PasswordVaultRepository.php
+++ b/app/Repositories/Models/PasswordVaultRepository.php
@@ -3,23 +3,32 @@
 namespace App\Repositories\Models;
 
 use App\Models\PasswordVault;
+use App\Services\Models\UserService;
 use App\Services\Utils\PasswordGeneratorService;
 
 class PasswordVaultRepository extends BaseRepository
 {
     private $PasswordGeneratorService;
 
+    private $userService;
+
     const RELATIONS = [];
 
-    public function __construct(PasswordVault $model, PasswordGeneratorService $PasswordGeneratorService)
+    public function __construct(PasswordVault $model, PasswordGeneratorService $PasswordGeneratorService, UserService $userService)
     {
         parent::__construct($model, self::RELATIONS);
         $this->PasswordGeneratorService = $PasswordGeneratorService;
+        $this->userService = $userService;
     }
 
     public function getModel($search = null, $startDate = null, $endDate = null)
     {
         $query = $this->model->withUserProfile();
+
+        if ($this->userService->getAuthUser()->hasRole('Staff')) {
+            $query->filterByUserAccess($this->userService->getAuthUserId());
+        }
+
         if ($search || $startDate || $endDate) {
             $query->searchData($search, $startDate, $endDate);
         }

--- a/resources/js/Pages/PasswordShare/List.vue
+++ b/resources/js/Pages/PasswordShare/List.vue
@@ -171,10 +171,9 @@
                                             :roles="[
                                                 'super usuario',
                                                 'super_admin',
+                                                'Staff',
                                             ]"
-                                            :permissions="[
-                                                'update_password_share',
-                                            ]"
+                                            :permissions="[]"
                                             @click="
                                                 $inertia.visit(
                                                     route(


### PR DESCRIPTION
This pull request introduces access control improvements for password vault data, primarily by adding logic to filter records based on the authenticated user's role and permissions. The changes ensure that staff users only see vault entries they have access to, and update the frontend to reflect new permission requirements.

**Backend: Access Control Enhancements**
* Added a new `scopeFilterByUserAccess` method to the `PasswordVault` model to restrict queries to vaults that are public, owned by the user, or shared with the user with view/edit permissions.
* Updated the `PasswordVaultRepository` to inject `UserService` and apply the new access filter for users with the 'Staff' role when retrieving models.

**Frontend: Permission Updates**
* Modified the roles and permissions for the password share list page, adding 'Staff' to allowed roles and removing specific permission requirements for the update action.…swordVaultRepository to utilize it; adjust permissions in PasswordShare List component


><img width="1152" height="509" alt="image" src="https://github.com/user-attachments/assets/c8a1607e-d627-4e3f-8548-b3521cf27365" />
